### PR TITLE
Don't treat parameters with an explicit index as named

### DIFF
--- a/.changeset/polite-rules-cut.md
+++ b/.changeset/polite-rules-cut.md
@@ -1,0 +1,5 @@
+---
+"@powersync/better-sqlite3": minor
+---
+
+Don't treat SQL parameters with an explicit index (e.g. `?1`) as a named parameter.

--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -2,7 +2,7 @@
 //
 
 #include "better_sqlite3.hpp"
-#line 165 "./src/util/macros.lzz"
+#line 167 "./src/util/macros.lzz"
 void SetPrototypeGetter(
 	v8::Isolate* isolate,
 	v8::Local<v8::External> data,
@@ -30,7 +30,7 @@ void SetPrototypeGetter(
 	);
 	#endif
 }
-#line 195 "./src/util/macros.lzz"
+#line 197 "./src/util/macros.lzz"
 #ifndef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
 #define SAFE_NEW_BUFFER(env, data, length, finalizeCallback, finalizeHint) node::Buffer::New(env, data, length, finalizeCallback, finalizeHint)
 #else
@@ -118,18 +118,18 @@ void ThrowRangeError (char const * message)
 #line 40 "./src/util/macros.lzz"
                                           { v8 :: Isolate * isolate = v8 :: Isolate :: GetCurrent ( ) ; isolate->ThrowException(v8::Exception::RangeError(StringFromUtf8(isolate, message, -1)));
 }
-#line 117 "./src/util/macros.lzz"
+#line 119 "./src/util/macros.lzz"
 v8::Local <v8::FunctionTemplate> NewConstructorTemplate (v8::Isolate * isolate, v8::Local <v8::External> data, v8::FunctionCallback func, char const * name)
-#line 122 "./src/util/macros.lzz"
+#line 124 "./src/util/macros.lzz"
   {
         v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(isolate, func, data);
         t->InstanceTemplate()->SetInternalFieldCount(1);
         t->SetClassName(InternalizedFromLatin1(isolate, name));
         return t;
 }
-#line 128 "./src/util/macros.lzz"
+#line 130 "./src/util/macros.lzz"
 void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::FunctionCallback func)
-#line 134 "./src/util/macros.lzz"
+#line 136 "./src/util/macros.lzz"
   {
         v8::HandleScope scope(isolate);
         recv->PrototypeTemplate()->Set(
@@ -137,9 +137,9 @@ void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v
                 v8::FunctionTemplate::New(isolate, func, data, v8::Signature::New(isolate, recv))
         );
 }
-#line 141 "./src/util/macros.lzz"
+#line 143 "./src/util/macros.lzz"
 void SetPrototypeSymbolMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, v8::Local <v8::Symbol> symbol, v8::FunctionCallback func)
-#line 147 "./src/util/macros.lzz"
+#line 149 "./src/util/macros.lzz"
   {
         v8::HandleScope scope(isolate);
         recv->PrototypeTemplate()->Set(
@@ -1020,7 +1020,7 @@ BindMap * Statement::GetBindMap (v8::Isolate * isolate)
                 int param_count = sqlite3_bind_parameter_count(handle);
                 for (int i = 1; i <= param_count; ++i) {
                         const char* name = sqlite3_bind_parameter_name(handle, i);
-                        if (name != NULL) bind_map->Add(isolate, name + 1, i);
+                        if ( ( name != NULL && name [ 0 ] != '?' ) ) bind_map->Add(isolate, name + 1, i);
                 }
                 has_bind_map = true;
                 return bind_map;
@@ -2221,12 +2221,19 @@ void Binder::Fail (void (* Throw) (char const *), char const * message)
 int Binder::NextAnonIndex ()
 #line 63 "./src/util/binder.lzz"
                             {
-                while (sqlite3_bind_parameter_name(handle, ++anon_index) != NULL) {}
+
+                while (true) {
+                        const char* name = sqlite3_bind_parameter_name(handle, ++anon_index);
+                        if (! ( name != NULL && name [ 0 ] != '?' ) ) {
+                                break;
+                        }
+                }
+
                 return anon_index;
 }
-#line 69 "./src/util/binder.lzz"
+#line 76 "./src/util/binder.lzz"
 void Binder::BindValue (v8::Isolate * isolate, v8::Local <v8::Value> value, int index)
-#line 69 "./src/util/binder.lzz"
+#line 76 "./src/util/binder.lzz"
                                                                                     {
                 int status = Data::BindValueFromJS(isolate, handle, index, value);
                 if (status != SQLITE_OK) {
@@ -2245,9 +2252,9 @@ void Binder::BindValue (v8::Isolate * isolate, v8::Local <v8::Value> value, int 
                         assert(false);
                 }
 }
-#line 90 "./src/util/binder.lzz"
+#line 97 "./src/util/binder.lzz"
 int Binder::BindArray (v8::Isolate * isolate, v8::Local <v8::Array> arr)
-#line 90 "./src/util/binder.lzz"
+#line 97 "./src/util/binder.lzz"
                                                                       {
                 v8 :: Local < v8 :: Context > ctx = isolate -> GetCurrentContext ( ) ;
                 uint32_t length = arr->Length();
@@ -2269,9 +2276,9 @@ int Binder::BindArray (v8::Isolate * isolate, v8::Local <v8::Array> arr)
                 }
                 return len;
 }
-#line 116 "./src/util/binder.lzz"
+#line 123 "./src/util/binder.lzz"
 int Binder::BindObject (v8::Isolate * isolate, v8::Local <v8::Object> obj, Statement * stmt)
-#line 116 "./src/util/binder.lzz"
+#line 123 "./src/util/binder.lzz"
                                                                                          {
                 v8 :: Local < v8 :: Context > ctx = isolate -> GetCurrentContext ( ) ;
                 BindMap* bind_map = stmt->GetBindMap(isolate);
@@ -2308,9 +2315,9 @@ int Binder::BindObject (v8::Isolate * isolate, v8::Local <v8::Object> obj, State
 
                 return len;
 }
-#line 160 "./src/util/binder.lzz"
+#line 167 "./src/util/binder.lzz"
 Binder::Result Binder::BindArgs (v8::FunctionCallbackInfo <v8 :: Value> const & info, int argc, Statement * stmt)
-#line 160 "./src/util/binder.lzz"
+#line 167 "./src/util/binder.lzz"
                                                                         {
                 v8 :: Isolate * isolate = info . GetIsolate ( ) ;
                 int count = 0;

--- a/src/better_sqlite3.hpp
+++ b/src/better_sqlite3.hpp
@@ -16,7 +16,7 @@
 #include <node.h>
 #include <node_object_wrap.h>
 #include <node_buffer.h>
-#line 156 "./src/util/macros.lzz"
+#line 158 "./src/util/macros.lzz"
 void SetPrototypeGetter(
 	v8::Isolate* isolate,
 	v8::Local<v8::External> data,
@@ -43,21 +43,21 @@ void ThrowError (char const * message);
 void ThrowTypeError (char const * message);
 #line 40 "./src/util/macros.lzz"
 void ThrowRangeError (char const * message);
-#line 103 "./src/util/macros.lzz"
+#line 105 "./src/util/macros.lzz"
 bool IS_SKIPPED (char c);
-#line 108 "./src/util/macros.lzz"
+#line 110 "./src/util/macros.lzz"
 template <typename T>
-#line 108 "./src/util/macros.lzz"
+#line 110 "./src/util/macros.lzz"
 T * ALLOC_ARRAY (size_t count);
-#line 113 "./src/util/macros.lzz"
+#line 115 "./src/util/macros.lzz"
 template <typename T>
-#line 113 "./src/util/macros.lzz"
+#line 115 "./src/util/macros.lzz"
 void FREE_ARRAY (T * array_pointer);
-#line 117 "./src/util/macros.lzz"
+#line 119 "./src/util/macros.lzz"
 v8::Local <v8::FunctionTemplate> NewConstructorTemplate (v8::Isolate * isolate, v8::Local <v8::External> data, v8::FunctionCallback func, char const * name);
-#line 128 "./src/util/macros.lzz"
+#line 130 "./src/util/macros.lzz"
 void SetPrototypeMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, char const * name, v8::FunctionCallback func);
-#line 141 "./src/util/macros.lzz"
+#line 143 "./src/util/macros.lzz"
 void SetPrototypeSymbolMethod (v8::Isolate * isolate, v8::Local <v8::External> data, v8::Local <v8::FunctionTemplate> recv, v8::Local <v8::Symbol> symbol, v8::FunctionCallback func);
 #line 1 "./src/util/constants.lzz"
 class CS
@@ -830,21 +830,21 @@ private:
   void Fail (void (* Throw) (char const *), char const * message);
 #line 63 "./src/util/binder.lzz"
   int NextAnonIndex ();
-#line 69 "./src/util/binder.lzz"
+#line 76 "./src/util/binder.lzz"
   void BindValue (v8::Isolate * isolate, v8::Local <v8::Value> value, int index);
-#line 90 "./src/util/binder.lzz"
+#line 97 "./src/util/binder.lzz"
   int BindArray (v8::Isolate * isolate, v8::Local <v8::Array> arr);
-#line 116 "./src/util/binder.lzz"
+#line 123 "./src/util/binder.lzz"
   int BindObject (v8::Isolate * isolate, v8::Local <v8::Object> obj, Statement * stmt);
-#line 160 "./src/util/binder.lzz"
+#line 167 "./src/util/binder.lzz"
   Result BindArgs (v8::FunctionCallbackInfo <v8 :: Value> const & info, int argc, Statement * stmt);
-#line 200 "./src/util/binder.lzz"
+#line 207 "./src/util/binder.lzz"
   sqlite3_stmt * handle;
-#line 201 "./src/util/binder.lzz"
+#line 208 "./src/util/binder.lzz"
   int param_count;
-#line 202 "./src/util/binder.lzz"
+#line 209 "./src/util/binder.lzz"
   int anon_index;
-#line 203 "./src/util/binder.lzz"
+#line 210 "./src/util/binder.lzz"
   bool success;
 };
 #line 34 "./src/better_sqlite3.lzz"
@@ -906,25 +906,25 @@ LZZ_INLINE void SetFrozen (v8::Isolate * isolate, v8::Local <v8::Context> ctx, v
                                                                                                                                                             {
         obj->DefineOwnProperty(ctx, key.Get(isolate), value, static_cast<v8::PropertyAttribute>(v8::DontDelete | v8::ReadOnly)).FromJust();
 }
-#line 103 "./src/util/macros.lzz"
+#line 105 "./src/util/macros.lzz"
 LZZ_INLINE bool IS_SKIPPED (char c)
-#line 103 "./src/util/macros.lzz"
+#line 105 "./src/util/macros.lzz"
                                {
         return c == ' ' || c == ';' || (c >= '\t' && c <= '\r');
 }
-#line 108 "./src/util/macros.lzz"
+#line 110 "./src/util/macros.lzz"
 template <typename T>
-#line 108 "./src/util/macros.lzz"
+#line 110 "./src/util/macros.lzz"
 LZZ_INLINE T * ALLOC_ARRAY (size_t count)
-#line 108 "./src/util/macros.lzz"
+#line 110 "./src/util/macros.lzz"
                                                       {
         return static_cast<T*>(::operator new[](count * sizeof(T)));
 }
-#line 113 "./src/util/macros.lzz"
+#line 115 "./src/util/macros.lzz"
 template <typename T>
-#line 113 "./src/util/macros.lzz"
+#line 115 "./src/util/macros.lzz"
 LZZ_INLINE void FREE_ARRAY (T * array_pointer)
-#line 113 "./src/util/macros.lzz"
+#line 115 "./src/util/macros.lzz"
                                                            {
         ::operator delete[](array_pointer);
 }

--- a/src/objects/statement.lzz
+++ b/src/objects/statement.lzz
@@ -29,7 +29,7 @@ public:
 		int param_count = sqlite3_bind_parameter_count(handle);
 		for (int i = 1; i <= param_count; ++i) {
 			const char* name = sqlite3_bind_parameter_name(handle, i);
-			if (name != NULL) bind_map->Add(isolate, name + 1, i);
+			if (IS_NAMED_PARAMETER(name)) bind_map->Add(isolate, name + 1, i);
 		}
 		has_bind_map = true;
 		return bind_map;

--- a/src/util/binder.lzz
+++ b/src/util/binder.lzz
@@ -61,7 +61,14 @@ private:
 	}
 
 	int NextAnonIndex() {
-		while (sqlite3_bind_parameter_name(handle, ++anon_index) != NULL) {}
+		// Find the next parameter index that isn't a named variable.
+		while (true) {
+			const char* name = sqlite3_bind_parameter_name(handle, ++anon_index);
+			if (!IS_NAMED_PARAMETER(name)) {
+				break;
+			}
+		}
+
 		return anon_index;
 	}
 

--- a/src/util/macros.lzz
+++ b/src/util/macros.lzz
@@ -88,6 +88,8 @@ void ThrowRangeError(const char* message) { EasyIsolate; isolate->ThrowException
 	if (stmt->locked)                                                          \
 		return ThrowTypeError("This statement is busy executing a query")
 
+#define IS_NAMED_PARAMETER(name) (name != NULL && name[0] != '?')
+
 #define first() 0
 #define second() 1
 #define third() 2

--- a/test/22.statement.all.js
+++ b/test/22.statement.all.js
@@ -99,6 +99,7 @@ describe('Statement#all()', function () {
 		const rows = [{ a: 'foo', b: 1, c: 3.14, d: Buffer.alloc(4).fill(0xdd), e: null }];
 		const SQL1 = 'SELECT * FROM entries WHERE a=? AND b=? AND c=? AND d=? AND e IS ?';
 		const SQL2 = 'SELECT * FROM entries WHERE a=@a AND b=@b AND c=@c AND d=@d AND e IS @e';
+		const SQL3 = 'SELECT * FROM entries WHERE a=?1 AND b=?1';
 		let result = this.db.prepare(SQL1).all('foo', 1, 3.14, Buffer.alloc(4).fill(0xdd), null);
 		expect(result).to.deep.equal(rows);
 
@@ -114,6 +115,9 @@ describe('Statement#all()', function () {
 		result = this.db.prepare(SQL2).all({ a: 'foo', b: 1, c: 3.14, d: Buffer.alloc(4).fill(0xaa), e: undefined });
 		expect(result).to.deep.equal([]);
 
+		result = this.db.prepare(SQL3).all(123);
+		expect(result).to.deep.equal([]);
+
 		expect(() =>
 			this.db.prepare(SQL2).all({ a: 'foo', b: 1, c: 3.14, d: Buffer.alloc(4).fill(0xdd) })
 		).to.throw(RangeError);
@@ -124,6 +128,18 @@ describe('Statement#all()', function () {
 
 		expect(() =>
 			this.db.prepare(SQL2).all({})
+		).to.throw(RangeError);
+
+		expect(() =>
+			this.db.prepare(SQL3).all({})
+		).to.throw(RangeError);
+
+		expect(() =>
+			this.db.prepare(SQL3).all([])
+		).to.throw(RangeError);
+
+		expect(() =>
+			this.db.prepare(SQL3).all(['one', 'too many'])
 		).to.throw(RangeError);
 	});
 });


### PR DESCRIPTION
Unlike most of the other libraries we use, `better-sqlite3` supports binding parameters by name, extracting values from an object. The way the current implementation works is that named parameters in fact _have_ to be given by name and can't be given as an array. For instance, the query `SELECT :name` can't be executed with `execute(['Simon'])`, one has to use `execute({name: 'Simon'})`.

Unfortunately, this requirement is also applied to variables that aren't named at all! The implementation just used to check for `sqlite3_bind_parameter_name` returning `NULL`, but that's not the case for parameters with an explicit index (e.g. `SELECT ?1`).
As a consequence, `better-sqlite3` behaves quite weirdly here and wouldn't allow that statement to be executed with `execute(['Simon'])`, one would have to use `{[1]: 'Simon'}` I suppose. This behavior is different from our other SDKs, which is obviously quite bad.

This PR fixes the internal check to treat `?NNN` variables as non-named. This should mostly keep backwards compatibility while also ensuring that we can use these parameters with `better-sqlite3`. There's still a problem if users other named variables (`SELECT :name`) because our Node SDK will pass an array to `better-sqlite3` which won't work.

One could argue that this approach of binding named parameters is fundamentally flawed to begin with (because in SQLite, named parameters also have an associated index). So passing an array to bind named parameters should be allowed, but it breaks `better-sqlite3`. I didn't want to do that change right now because I'd then have to also fix a lot of tests. But it might be worth ripping out all special checks for named parameters entirely to restore 